### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/justiceankomah12/d87dff4d-8d15-483f-8461-525c6b8a721d/5e00d638-042b-4c70-8c61-a782509e30ab/_apis/work/boardbadge/f31c4552-60d7-44a7-a93f-15c7b07bbfaa)](https://dev.azure.com/justiceankomah12/d87dff4d-8d15-483f-8461-525c6b8a721d/_boards/board/t/5e00d638-042b-4c70-8c61-a782509e30ab/Microsoft.RequirementCategory)
 # justicetutorials
 my repository for learning github and git


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/justiceankomah12/d87dff4d-8d15-483f-8461-525c6b8a721d/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.